### PR TITLE
Add Black formatter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black
-matlabengine
-PyQt6
-pytest-qt
+black==22.10.0
+matlabengine==9.13.1
+PyQt6==6.4.0
+pytest-qt==4.2.0


### PR DESCRIPTION
I used [Black formatter](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html) during PEY and I think it is a good addition to keep our code style clean and uniform. I think we should create a practice to run black on our edited files before committing.

For version specifiers, I removed them because I don't think its a big deal if we just use the latest version although now that I think of it it *might* be an issue if there are any big changes in a package. I think we should discuss and settle on the versions to use if we think it is necessary.