### PR TITLE
Implement the infrastructure of the application and setup widget skeletons for easy integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+widget_pages/__pycache__

--- a/app.py
+++ b/app.py
@@ -1,24 +1,77 @@
 # app.py
 
-"""Simple Hello, World example with PyQt6."""
+# Entry point to the entire application. This file contains the
+# main infrastructure of the application.
 
-import sys
+from PyQt6.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QMainWindow,
+    QPushButton,
+    QStackedLayout,
+    QVBoxLayout,
+    QWidget,
+)
 
-# 1. Import QApplication and all the required widgets
-from PyQt6.QtWidgets import QApplication, QLabel, QWidget
+from widget_pages.dashboard import DashboardWindow
+from widget_pages.login import LoginWindow
+from widget_pages.patient_information import PatientInformationWindow
+from widget_pages.patient_list import PatientListWindow
 
-# 2. Create an instance of QApplication
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+
+        pageLayout = QVBoxLayout()
+        buttonLayout = QHBoxLayout()
+        self.stackLayout = QStackedLayout()
+
+        pageLayout.addLayout(buttonLayout)
+        pageLayout.addLayout(self.stackLayout)
+
+        button = QPushButton("Login")
+        button.pressed.connect(self.showLoginWindow)
+        buttonLayout.addWidget(button)
+        self.stackLayout.addWidget(LoginWindow())
+
+        button = QPushButton("Patient List")
+        button.pressed.connect(self.showPatientListWindow)
+        buttonLayout.addWidget(button)
+        self.stackLayout.addWidget(PatientListWindow())
+
+        button = QPushButton("Patient Information")
+        button.pressed.connect(self.showPatientInformationWindow)
+        buttonLayout.addWidget(button)
+        self.stackLayout.addWidget(PatientInformationWindow())
+
+        button = QPushButton("Dashboard")
+        button.pressed.connect(self.showDashboardWindow)
+        buttonLayout.addWidget(button)
+        self.stackLayout.addWidget(DashboardWindow())
+
+        widget = QWidget()
+        widget.setLayout(pageLayout)
+        self.setCentralWidget(widget)
+        self.showMaximized()
+
+    def showLoginWindow(self):
+        self.stackLayout.setCurrentIndex(0)
+
+    def showPatientListWindow(self):
+        self.stackLayout.setCurrentIndex(1)
+
+    def showPatientInformationWindow(self):
+        self.stackLayout.setCurrentIndex(2)
+
+    def showDashboardWindow(self):
+        self.stackLayout.setCurrentIndex(3)
+
+
 app = QApplication([])
 
-# 3. Create your application's GUI
-window = QWidget()
-window.setWindowTitle("PyQt App")
-window.setGeometry(100, 100, 280, 80)
-helloMsg = QLabel("<h1>Hello, World!</h1>", parent=window)
-helloMsg.move(60, 15)
-
-# 4. Show your application's GUI
+window = MainWindow()
+window.setWindowTitle("Leukemia Treatment Application")
 window.show()
 
-# 5. Run your application's event loop
-sys.exit(app.exec())
+app.exec()

--- a/widget_pages/dashboard.py
+++ b/widget_pages/dashboard.py
@@ -1,0 +1,24 @@
+from PyQt6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
+
+
+class DashboardWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+
+        layout = QVBoxLayout()
+        button1 = QPushButton("Back to Patient List")
+        button2 = QPushButton("Back to Patient Information")
+        button1.clicked.connect(self.showPatientListWindow)
+        button2.clicked.connect(self.showPatientInformationWindow)
+
+        layout.addWidget(QLabel("Dashboard Window"))
+        layout.addWidget(button1)
+        layout.addWidget(button2)
+
+        self.setLayout(layout)
+
+    def showPatientListWindow(self):
+        self.parent().parent().showPatientListWindow()
+
+    def showPatientInformationWindow(self):
+        self.parent().parent().showPatientInformationWindow()

--- a/widget_pages/login.py
+++ b/widget_pages/login.py
@@ -1,0 +1,18 @@
+from PyQt6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
+
+
+class LoginWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+
+        layout = QVBoxLayout()
+        button = QPushButton("Show Patient List")
+        button.clicked.connect(self.showPatientListWindow)
+
+        layout.addWidget(QLabel("Login Window"))
+        layout.addWidget(button)
+
+        self.setLayout(layout)
+
+    def showPatientListWindow(self):
+        self.parent().parent().showPatientListWindow()

--- a/widget_pages/patient_information.py
+++ b/widget_pages/patient_information.py
@@ -1,0 +1,24 @@
+from PyQt6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
+
+
+class PatientInformationWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+
+        layout = QVBoxLayout()
+        button1 = QPushButton("Back to Patient List")
+        button2 = QPushButton("Show Dashboard")
+        button1.clicked.connect(self.showPatientListWindow)
+        button2.clicked.connect(self.showDashboardWindow)
+
+        layout.addWidget(QLabel("Patient Information Window"))
+        layout.addWidget(button1)
+        layout.addWidget(button2)
+
+        self.setLayout(layout)
+
+    def showPatientListWindow(self):
+        self.parent().parent().showPatientListWindow()
+
+    def showDashboardWindow(self):
+        self.parent().parent().showDashboardWindow()

--- a/widget_pages/patient_list.py
+++ b/widget_pages/patient_list.py
@@ -1,0 +1,18 @@
+from PyQt6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
+
+
+class PatientListWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+
+        layout = QVBoxLayout()
+        button = QPushButton("Show Patient Information")
+        button.clicked.connect(self.showPatientInformationWindow)
+
+        layout.addWidget(QLabel("Patient List Window"))
+        layout.addWidget(button)
+
+        self.setLayout(layout)
+
+    def showPatientInformationWindow(self):
+        self.parent().parent().showPatientInformationWindow()


### PR DESCRIPTION
For the application, I am currently using `QStackedLayout` and simply switching to the corresponding widget when it's appropriate. This made the most sense to me but feel free to leave any suggestions if you guys think there's a better way to do it. 

`app.py` you guys should not need to touch.
`widget_pages` contains all the `.py` files you guys would need to implement. 

Currently, the `.py` files contain a widget skeleton that you guys can use to implement the individual widgets (pages). Allan has already raised a [PR ](https://github.com/liu-allan/Leukemia-Treatment-Application/pull/14) for his page. I have pulled that into another branch and have tried it with this infrastructure. It is working. The only changes required is that the `*Window` classes would need to inherit from the `QWidget` class and not the `QMainWindow` class as we should only have one main window. 

Note, to switch between different widgets, for example in the [case of Allan's login page](https://github.com/liu-allan/Leukemia-Treatment-Application/pull/14/files#diff-e83e4cbc9095e7e47374162c94b70a277fe356a3f103fd9532c9b4c1f3fff87bR36), please use the method `self.parent().parent().show*Window()` defined in `app.py`.

I have set up a bare bone UI for you guys to try (see below). Note that the buttons on the top will be removed, it is temporarily there for convenience and testing. 

![image](https://user-images.githubusercontent.com/44624592/201428749-8a9c87cc-09c4-490c-92fa-9388ff29a195.png)
