### PR TITLE
Clear the username and password after logging in

### DIFF
--- a/widget_pages/login.py
+++ b/widget_pages/login.py
@@ -61,3 +61,5 @@ class LoginWindow(QWidget):
 
     def showPatientListWindow(self):
         self.parent().parent().showPatientListWindow()
+        self.usernameLineEdit.clear()
+        self.passwordLineEdit.clear()


### PR DESCRIPTION
#28 After logging off, we go back to the login page. The user name and password still stay there, do we want to have that? (Security issue?)

Now after logging in, the username and password fields are cleared. 