### PR TITLE
Add label for Patient Name and Date of ANC measurement

### DIFF
--- a/ui/patientInformationForm.ui
+++ b/ui/patientInformationForm.ui
@@ -20,6 +20,42 @@
    <property name="verticalSpacing">
     <number>25</number>
    </property>
+   <item row="3" column="0">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="patientLineEdit">
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="placeholderText">
+      <string>Patient</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="heightLabel">
+     <property name="text">
+      <string>Height (cm)</string>
+     </property>
+    </widget>
+   </item>
    <item row="6" column="2">
     <widget class="QLineEdit" name="ancMeasurementEdit">
      <property name="maximumSize">
@@ -33,19 +69,23 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
-    <widget class="QLineEdit" name="dosageEdit">
-     <property name="maximumSize">
-      <size>
-       <width>100</width>
-       <height>16777215</height>
-      </size>
+   <item row="2" column="1">
+    <widget class="QLabel" name="weightLabel">
+     <property name="text">
+      <string>Weight (kg)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QLabel" name="bodySurfaceAreaMeasurement">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
      <property name="text">
-      <string/>
-     </property>
-     <property name="placeholderText">
-      <string>mg</string>
+      <string>m^2</string>
      </property>
     </widget>
    </item>
@@ -68,7 +108,10 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="7" column="2">
+    <widget class="QDateEdit" name="dateEdit"/>
+   </item>
+   <item row="10" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="maximumSize">
       <size>
@@ -80,113 +123,6 @@
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Save</set>
      </property>
     </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QLabel" name="errorLabel">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QLabel" name="ancCountLabel">
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>ANC Measurement  (g/L)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="3">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="2">
-    <widget class="QLineEdit" name="heightEdit">
-     <property name="maximumSize">
-      <size>
-       <width>100</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="placeholderText">
-      <string>cm</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QLabel" name="bodySurfaceAreaMeasurement">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>m^2</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLineEdit" name="patientLineEdit">
-     <property name="maximumSize">
-      <size>
-       <width>100</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="placeholderText">
-      <string>Patient</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="0" column="1">
     <spacer name="verticalSpacer_2">
@@ -204,34 +140,10 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="1">
-    <widget class="QLabel" name="patientLabel">
+   <item row="5" column="1">
+    <widget class="QLabel" name="dosageLabel">
      <property name="text">
-      <string>Patient Name</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QLabel" name="dateLabel">
-     <property name="text">
-      <string>Date of ANC Measurement</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QDateEdit" name="dateEdit"/>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="weightLabel">
-     <property name="text">
-      <string>Weight (kg)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLabel" name="heightLabel">
-     <property name="text">
-      <string>Height (cm)</string>
+      <string>6-MP Dosage (mg)</string>
      </property>
     </widget>
    </item>
@@ -242,10 +154,104 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QLabel" name="dosageLabel">
+   <item row="3" column="3">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="11" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLabel" name="ancCountLabel">
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
      <property name="text">
-      <string>6-MP Dosage (mg)</string>
+      <string>ANC Measurement  (g/L)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLabel" name="dateLabel">
+     <property name="text">
+      <string>Date of ANC Measurement</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="patientLabel">
+     <property name="text">
+      <string>Patient Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QLineEdit" name="heightEdit">
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="placeholderText">
+      <string>cm</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QLineEdit" name="dosageEdit">
+     <property name="maximumSize">
+      <size>
+       <width>100</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="placeholderText">
+      <string>mg</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QLabel" name="errorLabel">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
#28 

>Patient Information page font size is really small on my computer (prob cuz I have a bigger screen), so should either change the pixel size or find a more responsive way of changing the font-size.

Is it just the patient information page that has a small font size? What about the Login page? I don't know why this one would be any different from the login. Could you please send a screenshot?

> Patient Information page: for the patient name should prob have a thing saying Patient name: Allan (I think that would be more rigorous?)

Done

>Patient Information page: what is the date for? Probably should also have a field name referring what that date is.
 
Done, the date is for when the measurement is taken. We need the date in order to be able to plug in the measured ANC (As opposed to using the simulated ANC)  into the model at the correct time step

> Patient Information page: should we always have the fields on edit mode? It would prob make more sense that we can edit it only if we are allowed to edit. Or else if somebody accidentally delete a data or smth (even though we have the save button) just because it is always on edit mode and somebody pressed delete accidentally.

I don't agree with this one. If fields were edited or deleted, nothing would be lost when pressing ok or cancel because these values are being loaded from the "database". If the user deleted a field, nothing is lost because the changes are not saved in the database and there is also verification in place to prevent saving empty fields. In my opinion, adding another edit button would just add another step to the UI. There is some trust involved that the user knows what they are doing but I feel like being able to log in should be enough verification that the user can edit these fields. 