### PR TITLE
Rewrite Patient Information page 

### DIFF
--- a/widget_pages/patient_information.py
+++ b/widget_pages/patient_information.py
@@ -21,19 +21,19 @@ logging.getLogger().setLevel(logging.INFO)
 
 
 class Label(QLabel):
-    def __init__(self, text):
+    def __init__(self, text, width=400):
         super().__init__()
         self.setText(text)
         self.setFont(QFont("Avenir", 12))
-        self.setFixedWidth(400)
+        self.setFixedWidth(width)
 
 
 class LineEdit(QLineEdit):
-    def __init__(self, placeholderText):
+    def __init__(self, placeholderText, width=200):
         super().__init__()
         self.setPlaceholderText(placeholderText)
         self.setFont(QFont("Avenir", 12))
-        self.setFixedWidth(200)
+        self.setFixedWidth(width)
 
 
 class FormRow(QWidget):


### PR DESCRIPTION
Rewrite instead of using .ui files.

![image](https://user-images.githubusercontent.com/44624435/213087815-8befafd4-3537-4498-bc11-c52281f3f0c7.png)


May be useful to use those helper classes such as `Label` and `LineEdit` elsewhere  so that we don't have to manually set the font every time.