### PR TITLE
Change patient form

### DIFF
--- a/widget_pages/patient_form.py
+++ b/widget_pages/patient_form.py
@@ -336,7 +336,6 @@ class PatientFormWindow(QWidget):
 
             self.parent().parent().updateSelectedPatient(patient_id)
             self.patient = self.parent().parent().selected_patient
-            self.showPatientListWindow()
 
         except sqlite3.Error as er:
             msg = "Existing entry in the database. Please check your inputs."
@@ -377,7 +376,8 @@ class PatientFormWindow(QWidget):
             self.ancEdited = False
             self.dosageEdited = False
             self.errorLabel.clear()
-            
+            self.showPatientListWindow()
+
     def calculateAge(self):
         today = datetime.today().date()
         return (


### PR DESCRIPTION
When writing the README, I noticed that when pressing Save or OK brings the user directly to the newly created patient information page. I think this can be confusing for users, so I have instead removed the ok button so that now the user must go back to the patient list page to then select the patient.